### PR TITLE
[MQ2Nav] Added command argument that will get height from shortest path.

### DIFF
--- a/common/NavMesh.cpp
+++ b/common/NavMesh.cpp
@@ -907,4 +907,44 @@ bool NavMesh::ImportJson(const std::string& filename, PersistedDataFields fields
 	return true;
 }
 
+std::vector<float> NavMesh::GetHeights(const glm::vec3& pos) {
+    std::vector<float> heights;
+
+    const float center[3] = { pos.x, pos.y, pos.z };
+    const float extents[3] = { 1.f, m_boundsMax.y - m_boundsMin.y, 1.f };
+    dtQueryFilter filter;
+    dtPolyRef polys[128];
+    int polyCount;
+    
+    // we will still get success on 0 polys, but it won't matter
+    auto query = GetNavMeshQuery();
+    if (IsNavMeshLoaded() && query && !(query->queryPolygons(center, extents, &filter, polys, &polyCount, 128) & DT_FAILURE)) {
+        for (int idx_poly = 0; idx_poly < polyCount; ++idx_poly) {
+            dtPolyRef poly = polys[idx_poly];
+            float height;
+
+            // this can fail with valid coords, so we need to make sure we are only adding valid heights.
+            if (!(query->getPolyHeight(poly, center, &height) & DT_FAILURE))
+                heights.push_back(height);
+        }
+    }
+
+    return heights;
+}
+
+float NavMesh::GetClosestHeight(const glm::vec3& pos) {
+    float height = pos.y;
+    auto heights = GetHeights(pos);
+    std::sort(heights.begin(), heights.end());
+
+    auto height_it = std::lower_bound(heights.begin(), heights.end(), pos.y);
+    if (height_it == heights.end() && height_it != heights.begin())
+        --height_it;
+    else if (height_it != heights.end() && height_it != heights.begin() &&
+        std::abs(*height_it - pos.y) > std::abs(*(height_it - 1) - pos.y))
+        --height_it;
+
+    return height_it == heights.end() ? pos.y : *height_it;
+}
+
 //============================================================================

--- a/common/NavMesh.h
+++ b/common/NavMesh.h
@@ -86,6 +86,12 @@ public:
 	bool ExportJson(const std::string& filename, PersistedDataFields fields);
 	bool ImportJson(const std::string& filename, PersistedDataFields fields);
 
+    //----------------------------------------------------------------------------
+    // navmesh queries
+
+    std::vector<float> GetHeights(const glm::vec3& pos);
+    float GetClosestHeight(const glm::vec3& pos);
+
 	//----------------------------------------------------------------------------
 	// navmesh data
 

--- a/plugin/MQ2Navigation.h
+++ b/plugin/MQ2Navigation.h
@@ -63,6 +63,12 @@ enum class ClickType
 	Once
 };
 
+enum class HeightType
+{
+    Explicit,
+    Nearest
+};
+
 enum class NotifyType
 {
 	None,
@@ -81,6 +87,7 @@ struct DestinationInfo
 	PDOOR pDoor = nullptr;
 	PGROUNDITEM pGroundItem = nullptr;
 	ClickType clickType = ClickType::None;
+    HeightType heightType = HeightType::Explicit;
 
 	bool valid = false;
 };

--- a/plugin/NavigationPath.cpp
+++ b/plugin/NavigationPath.cpp
@@ -77,6 +77,25 @@ void NavigationPath::SetShowNavigationPaths(bool renderPaths)
 void NavigationPath::SetDestination(const std::shared_ptr<DestinationInfo>& info)
 {
 	m_destinationInfo = info;
+
+    // do this here because we don't want to keep calculating this every time an update is called
+	auto* mesh = g_mq2Nav->Get<NavMesh>();
+    if (m_destinationInfo && m_destinationInfo->heightType == HeightType::Nearest && mesh)
+    {
+        glm::vec3 transformed = { m_destinationInfo->eqDestinationPos.x, m_destinationInfo->eqDestinationPos.z, m_destinationInfo->eqDestinationPos.y };
+        auto heights = mesh->GetHeights(transformed);
+
+        // we don't actually want to calculate the path at  the current height since there is no guarantee it is on the mesh
+        float current_distance = std::numeric_limits<float>().max();
+
+        for (auto height : heights) {
+            float current_height = m_destinationInfo->eqDestinationPos.z;
+            m_destinationInfo->eqDestinationPos.z = height;
+            if (!FindPath() || GetPathTraversalDistance() > current_distance) {
+                m_destinationInfo->eqDestinationPos.z = current_height;
+            } // else leave it, it's a better height
+        }
+    }
 }
 
 bool NavigationPath::FindPath()


### PR DESCRIPTION
This is a feature add that uses a `queryPolygons` call to get all hits at an `xz`, grabs the `y` coordinate (calling it `height`). The argument to `/nav` I added here will take an x and y from the user then calculate paths at the time of the command and pick the height with the shortest path. Other than that, it's exactly `/nav loc` and variations.