### PR TITLE
Added camera movement speed slider .

### DIFF
--- a/meshgen/Application.cpp
+++ b/meshgen/Application.cpp
@@ -544,8 +544,8 @@ void Application::UpdateCamera()
 	m_moveD = rcClamp(m_moveD + m_timeDelta * 4 * (keystate[SDL_SCANCODE_D] ? 1 : -1), 0.0f, 1.0f);
 	m_moveUp = rcClamp(m_moveUp + m_timeDelta * 4 * (keystate[SDL_SCANCODE_SPACE] ? 1 : -1), 0.0f, 1.0f);
 	m_moveDown = rcClamp(m_moveDown + m_timeDelta * 4 * (keystate[SDL_SCANCODE_C] ? 1 : -1), 0.0f, 1.0f);
-
-	float keybSpeed = 250.0f;
+	
+	float keybSpeed = m_camMoveSpeed;
 	if (SDL_GetModState() & KMOD_SHIFT)
 		keybSpeed *= 10.0f;
 
@@ -788,6 +788,8 @@ void Application::RenderInterface()
 					SaveMesh();
 			}
 		}
+		ImGui::Separator();
+		ImGui::SliderFloat("Cam Movement Speed", &m_camMoveSpeed, 10, 350);
 
 		ImGui::End();
 	}

--- a/meshgen/Application.h
+++ b/meshgen/Application.h
@@ -236,6 +236,9 @@ private:
 	bool m_showProperties = true;
 	bool m_showMapAreas = false;
 	bool m_showOverlay = true;
+	
+	// Keyboard speed adjustment
+	float m_camMoveSpeed = 250.0f;
 
 	// zone to load on next pass
 	std::string m_nextZoneToLoad;


### PR DESCRIPTION
This pull request allows the user to fine tune their camera speed via a slider in the Properties windows. The properties window seemed like the most logical/convenient place for such a slider. Tested for fine grain movement support on exalted which is painful to navigate with the default keyboard speed setting.