### PR TITLE
Update vcpkg_mq_ARCH

### DIFF
--- a/common/vcpkg_mq_x64.txt
+++ b/common/vcpkg_mq_x64.txt
@@ -1,5 +1,1 @@
-fmt
-glm
-protobuf
-rapidjson
-spdlog
+dxsdk-d3dx:x64-windows

--- a/common/vcpkg_mq_x86.txt
+++ b/common/vcpkg_mq_x86.txt
@@ -1,0 +1,1 @@
+dxsdk-d3dx:x86-windows


### PR DESCRIPTION
- Remove common packages from x64
- Add dxsdk-d3dx dynamic dependency for x86 and x64