### PR TITLE
Adjust the color of Disabled poly's from pruning.

### DIFF
--- a/meshgen/NavMeshTool.cpp
+++ b/meshgen/NavMeshTool.cpp
@@ -469,7 +469,7 @@ void NavMeshTool::handleRender()
 			if (m_drawMode == DrawMode::NAVMESH_NODES)
 				duDebugDrawNavMeshNodes(&dd, *navQuery);
 
-			duDebugDrawNavMeshPolysWithFlags(&dd, *navMesh, +PolyFlags::Disabled, duRGBA(0, 0, 0, 128));
+			duDebugDrawNavMeshPolysWithFlags(&dd, *navMesh, +PolyFlags::Disabled, duRGBA(192, 48, 0, 128));
 		}
 	}
 


### PR DESCRIPTION
As per our discussion.
This will give the pruned portion of the mesh a drastically different color so that it's apparent it has been pruned. 
![image](https://github.com/brainiac/MQ2Nav/assets/4873713/75a6e719-2e50-4a67-9242-4655fd7e8fbd)
