### PR TITLE
Add GLM_ENABLE_EXPERIMENTAL

### DIFF
--- a/Properties.props
+++ b/Properties.props
@@ -5,7 +5,7 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;GLM_FORCE_SWIZZLE;GLM_FORCE_RADIANS;GLM_FORCE_CTOR_INIT;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;GLM_FORCE_SWIZZLE;GLM_FORCE_RADIANS;GLM_FORCE_CTOR_INIT;GLM_ENABLE_EXPERIMENTAL;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/plugin/pch.h
+++ b/plugin/pch.h
@@ -12,6 +12,9 @@
 #if !defined(GLM_FORCE_CTOR_INIT)
 #error Missing GLM_FORCE_CTOR_INIT define!
 #endif
+#if !defined(GLM_ENABLE_EXPERIMENTAL)
+#error Missing GLM_ENABLE_EXPERIMENTAL define!
+#endif
 
 #include <imgui.h>
 #include <fmt/format.h>


### PR DESCRIPTION
With GLM version 1.0, the experimental functions of GLM have been formalized and require the GLM_ENABLE_EXPERIMENTAL property to be set in order to use them. Since MQ2Nav uses these functions, this PR adds GLM_ENABLE_EXPERIMENTAL.