### PR TITLE
Ignore Anniversary Doors for autoclicking

### DIFF
--- a/plugin/SwitchHandler.cpp
+++ b/plugin/SwitchHandler.cpp
@@ -37,6 +37,11 @@ inline bool SwitchIsNeighborhoodDoor(uint8_t typeId)
 	return typeId == 161;
 }
 
+inline bool IAmInAnniversaryTower()
+{
+	return pLocalPC ? pWorldData->GetZoneBaseId(pLocalPC->zoneId) == 869 : true;
+}
+
 SwitchHandler::SwitchHandler()
 	: m_slowUpdateInterval(1s)
 	, m_fastUpdateInterval(50ms)
@@ -58,6 +63,7 @@ inline bool ShouldAutoUseSwitch(PDOOR door)
 	if (door && door->bVisible && door->bUsable
 		&& !SwitchIsTeleporter(door->Type)
 		&& !SwitchIsNeighborhoodDoor(door->Type)
+		&& !IAmInAnniversaryTower()
 		&& door->Key == -1 /* todo: support keys */)
 	{
 		// if door is scripted, and option to ignore scripted doors is enabled,


### PR DESCRIPTION
- Autoclicking Anniversary doors makes you zone out of the mini "instances"
