### PR TITLE
Update for vcpkg updates & Common.props fixes

### DIFF
--- a/cli/MQ2Nav_ConsoleTool.vcxproj
+++ b/cli/MQ2Nav_ConsoleTool.vcxproj
@@ -70,7 +70,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>fmtd.lib;zlibd.lib;libprotobufd.lib;imm32.lib;setupapi.lib;openGL32.lib;glu32.lib;winmm.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>fmtd.lib;zlibd.lib;imm32.lib;setupapi.lib;openGL32.lib;glu32.lib;winmm.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ProjectDir)..\dependencies\sdl\lib;$(ProjectDir)..\dependencies\zlib\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
@@ -91,7 +91,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>fmt.lib;zlib.lib;libprotobuf.lib;imm32.lib;setupapi.lib;openGL32.lib;glu32.lib;winmm.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>fmt.lib;zlib.lib;imm32.lib;setupapi.lib;openGL32.lib;glu32.lib;winmm.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>

--- a/common/JsonProto.cpp
+++ b/common/JsonProto.cpp
@@ -265,10 +265,10 @@ static rapidjson::Value ParseMessage(const google::protobuf::Message* msg,
 	{
 		const google::protobuf::FieldDescriptor* field = descriptor->field(index);
 
-		if (!field->is_optional() || reflection->HasField(*msg, field))
+		if (field->is_required() || field->is_repeated() || reflection->HasField(*msg, field))
 		{
 			rapidjson::Value jsonField = FieldToJson(msg, field, allocator);
-			root.AddMember(rapidjson::Value{ field->name().c_str(),
+			root.AddMember(rapidjson::Value{ field->name().data(),
 				static_cast<rapidjson::SizeType>(field->name().size()) },
 				jsonField, allocator);
 		}

--- a/common/NavMesh.cpp
+++ b/common/NavMesh.cpp
@@ -9,6 +9,7 @@
 #include "common/proto/NavMeshFile.pb.h"
 #include "mq/base/Enum.h"
 
+#include "extras/protobuf/ProtobufLibs.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/util/json_util.h"
@@ -1141,7 +1142,7 @@ bool NavMesh::ExportJson(const std::string& filename, PersistedDataFields fields
 	//options.always_print_primitive_fields = true;
 
 	std::string jsonString;
-	google::protobuf::util::Status status =
+	absl::Status status =
 		google::protobuf::util::MessageToJsonString(proto, &jsonString, options);
 	if (status.ok())
 	{
@@ -1180,7 +1181,7 @@ bool NavMesh::ImportJson(const std::string& filename, PersistedDataFields fields
 	options.ignore_unknown_fields = true;
 
 	nav::NavMeshFile proto;
-	google::protobuf::util::Status status =
+	absl::Status status =
 		google::protobuf::util::JsonStringToMessage(contents,
 			&proto, options);
 	if (!status.ok())

--- a/meshgen/MeshGenerator.vcxproj
+++ b/meshgen/MeshGenerator.vcxproj
@@ -143,7 +143,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>fmtd.lib;zlibd.lib;libprotobufd.lib;SDL2-staticd.lib;SDL2maind.lib;imm32.lib;setupapi.lib;openGL32.lib;glu32.lib;winmm.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>fmtd.lib;zlibd.lib;SDL2-staticd.lib;SDL2maind.lib;imm32.lib;setupapi.lib;openGL32.lib;glu32.lib;winmm.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <Manifest>
@@ -170,7 +170,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>fmt.lib;zlib.lib;libprotobuf.lib;SDL2-static.lib;SDL2main.lib;imm32.lib;setupapi.lib;openGL32.lib;glu32.lib;winmm.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>fmt.lib;zlib.lib;SDL2-static.lib;SDL2main.lib;imm32.lib;setupapi.lib;openGL32.lib;glu32.lib;winmm.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <Manifest>

--- a/meshgen/targetver.h
+++ b/meshgen/targetver.h
@@ -1,9 +1,5 @@
 #pragma once
 
-// Including SDKDDKVer.h defines the highest available Windows platform.
-
-// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
-// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
-#define  _WIN32_WINNT 0x600
+// _WIN32_WINNT is defined in Common.props
 
 #include <SDKDDKVer.h>

--- a/plugin/MQ2Nav.vcxproj
+++ b/plugin/MQ2Nav.vcxproj
@@ -132,8 +132,8 @@
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <OptimizeReferences Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</OptimizeReferences>
       <OptimizeReferences Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</OptimizeReferences>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libprotobufd.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libprotobuf.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
- Move protobuf include into pragma (it depends on abseil now and the header carries all the deps)
- Update for protobuf deprecations & library changes
- _WIN32_WINNT was defined in common.props (but wrong) and fixing that caused a redefinition here, so just removed it with the note